### PR TITLE
support custom separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 /* jshint node: true */
 'use strict';
 
-var reSep = /[\/\.]/;
-
 /**
   # wildcard
 
@@ -30,8 +28,9 @@ var reSep = /[\/\.]/;
   <https://github.com/isaacs/node-glob>
 **/
 
-function WildcardMatcher(text) {
-  this.parts = (text || '').split(reSep);
+function WildcardMatcher(text, separator) {
+  this.separator = separator;
+  this.parts = (text || '').split(separator);
 }
 
 WildcardMatcher.prototype.match = function(input) {
@@ -42,7 +41,7 @@ WildcardMatcher.prototype.match = function(input) {
   var testParts;
 
   if (typeof input == 'string' || input instanceof String) {
-    testParts = (input || '').split(reSep);
+    testParts = (input || '').split(this.separator);
     for (ii = 0; matches && ii < partsCount; ii++) {
       matches = parts[ii] === '*' || parts[ii] === testParts[ii];
     }
@@ -69,8 +68,8 @@ WildcardMatcher.prototype.match = function(input) {
   return matches;
 };
 
-module.exports = function(text, test) {
-  var matcher = new WildcardMatcher(text);
+module.exports = function(text, test, separator) {
+  var matcher = new WildcardMatcher(text, separator || /[\/\.]/);
   if (typeof test != 'undefined') {
     return matcher.match(test);
   }

--- a/test/arrays.js
+++ b/test/arrays.js
@@ -5,6 +5,12 @@ var test = require('tape'),
         'a.b',
         'a',
         'a.b.d'
+    ],
+    testdataSep = [
+        'a:b:c',
+        'a:b',
+        'a',
+        'a:b:d'
     ];
 
 test('array result matching tests', function(t) {
@@ -14,4 +20,13 @@ test('array result matching tests', function(t) {
     t.equal(wildcard('a.b.*', testdata).length, 3, '3 matches found');
     t.equal(wildcard('a.*.c', testdata).length, 1);
     t.equal(wildcard('b.*.d', testdata).length, 0);
+});
+
+test('array result with separator matching tests', function(t) {
+    t.plan(4);
+
+    t.equal(wildcard('a:*', testdataSep, ':').length, 4, '4 matches found');
+    t.equal(wildcard('a:b:*', testdataSep, ':').length, 3, '3 matches found');
+    t.equal(wildcard('a:*:c', testdataSep, ':').length, 1);
+    t.equal(wildcard('b:*:d', testdataSep, ':').length, 0);
 });

--- a/test/objects.js
+++ b/test/objects.js
@@ -5,8 +5,14 @@ var wildcard = require('../'),
         'a.b'   : {},
         'a'     : {},
         'a.b.d' : {}
+    },
+    testdataSep = {
+        'a:b:c' : {},
+        'a:b'   : {},
+        'a'     : {},
+        'a:b:d' : {}
     };
-    
+
 test('object result matching tests', function(t) {
     t.test('should return 4 matches for a.*', function(t) {
         var matches = wildcard('a.*', testdata);
@@ -16,6 +22,17 @@ test('object result matching tests', function(t) {
         t.ok(matches['a.b']);
         t.ok(matches['a']);
         t.ok(matches['a.b.d']);
+        t.end();
+    });
+
+    t.test('should return 4 matches for a:*', function(t) {
+        var matches = wildcard('a:*', testdataSep, ':');
+
+        t.plan(4);
+        t.ok(matches['a:b:c']);
+        t.ok(matches['a:b']);
+        t.ok(matches['a']);
+        t.ok(matches['a:b:d']);
         t.end();
     });
 
@@ -30,9 +47,20 @@ test('object result matching tests', function(t) {
         t.end();
     });
 
+    t.test('should return 3 matches for a:b:*', function(t) {
+        var matches = wildcard('a:b:*', testdataSep, ':');
+
+        t.plan(4);
+        t.ok(matches['a:b:c']);
+        t.ok(matches['a:b']);
+        t.notOk(matches['a']);
+        t.ok(matches['a:b:d']);
+        t.end();
+    });
+
     t.test('should return 1 matches for a.*.c', function(t) {
         var matches = wildcard('a.*.c', testdata);
-            
+
         t.plan(4);
         t.ok(matches['a.b.c']);
         t.notOk(matches['a.b']);
@@ -40,15 +68,37 @@ test('object result matching tests', function(t) {
         t.notOk(matches['a.b.d']);
         t.end();
     });
-    
+
+    t.test('should return 1 matches for a:*:c', function(t) {
+        var matches = wildcard('a:*:c', testdataSep, ':');
+
+        t.plan(4);
+        t.ok(matches['a:b:c']);
+        t.notOk(matches['a:b']);
+        t.notOk(matches['a']);
+        t.notOk(matches['a:b:d']);
+        t.end();
+    });
+
     t.test('should return 0 matches for b.*.d', function(t) {
         var matches = wildcard('b.*.d', testdata);
-        
+
         t.plan(4);
         t.notOk(matches['a.b.c']);
         t.notOk(matches['a.b']);
         t.notOk(matches['a']);
         t.notOk(matches['a.b.d']);
+        t.end();
+    });
+
+    t.test('should return 0 matches for b:*:d', function(t) {
+        var matches = wildcard('b:*:d', testdataSep, ':');
+
+        t.plan(4);
+        t.notOk(matches['a:b:c']);
+        t.notOk(matches['a:b']);
+        t.notOk(matches['a']);
+        t.notOk(matches['a:b:d']);
         t.end();
     });
 

--- a/test/strings.js
+++ b/test/strings.js
@@ -1,6 +1,6 @@
 var test = require('tape'),
     wildcard = require('../');
-    
+
 test('general wild card matching tests', function(t) {
 
     t.plan(5);
@@ -9,4 +9,14 @@ test('general wild card matching tests', function(t) {
     t.notOk(wildcard('foo.*', 'bar'), 'foo.* should not match bar');
     t.ok(wildcard('a.*.c', 'a.b.c'), 'a.*.c should match a.b.c');
     t.notOk(wildcard('a.*.c', 'a.b'), 'a.*.c should not match a.b');
+});
+
+test('general wild card with separator matching tests', function(t) {
+
+    t.plan(5);
+    t.ok(wildcard('foo:*', 'foo:bar', ':'), 'foo:* should match foo:bar');
+    t.ok(wildcard('foo:*', 'foo', ':'), 'foo:* should match foo');
+    t.notOk(wildcard('foo:*', 'bar', ':'), 'foo:* should not match bar');
+    t.ok(wildcard('a:*:c', 'a:b:c', ':'), 'a:*:c should match a:b:c');
+    t.notOk(wildcard('a:*:c', 'a:b', ':'), 'a:*:c should not match a:b');
 });


### PR DESCRIPTION
With custom separator I can do wildcard searches in strings like `controller:users`. I implemented this passing a third param to wildcard method. Example:

``` javascript
var wildcard = require('wildcard');

var registry = {
  'controller:users': true,
  'controller:posts': false
};

wildcard('controller:*', registry, ':');
//=> {  'controller:users': true, 'controller:posts': false }
```
