### PR TITLE
Change the return type for string matches to be the array of parts

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,8 +43,10 @@ WildcardMatcher.prototype.match = function(input) {
   if (typeof input == 'string' || input instanceof String) {
     testParts = (input || '').split(this.separator);
     for (ii = 0; matches && ii < partsCount; ii++) {
-      matches = parts[ii] === '*' || parts[ii] === testParts[ii];
+      matches = parts[ii] === '*' || parts[ii] === testParts[ii];      
     }
+    // If matches, then return the component parts
+    matches = matches && testParts;
   }
   else if (typeof input.splice == 'function') {
     matches = [];

--- a/test/strings.js
+++ b/test/strings.js
@@ -20,3 +20,16 @@ test('general wild card with separator matching tests', function(t) {
     t.ok(wildcard('a:*:c', 'a:b:c', ':'), 'a:*:c should match a:b:c');
     t.notOk(wildcard('a:*:c', 'a:b', ':'), 'a:*:c should not match a:b');
 });
+
+test('general wild card with tokens being returned', function(t) {
+
+    t.plan(5);
+    var parts = wildcard('foo.*', 'foo.bar');
+    t.ok(parts);
+    t.equal(parts.length, 2);
+    t.equal(parts[0], 'foo');
+    t.equal(parts[1], 'bar');
+
+    parts = wildcard('foo.*', 'not.matching');
+    t.notOk(parts);
+});


### PR DESCRIPTION
To allow for efficient use of the matched string later, return the array of parts when a string matches the wildcard expression.
