### PR TITLE
use local node_modules path for command

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "http://github.com/DamonOehlman/wildcard/issues"
   },
   "scripts": {
-    "test": "node_modules/.bin/tape test/all.js",
+    "test": "node test/all.js",
     "gendocs": "gendocs > README.md"
   },
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "url": "http://github.com/DamonOehlman/wildcard/issues"
   },
   "scripts": {
-    "test": "$(npm bin)/tape test/all.js",
+    "test": "node_modules/.bin/tape test/all.js",
     "gendocs": "gendocs > README.md"
   },
   "main": "index.js",


### PR DESCRIPTION
Windows can't evaluate the expression, even with bash:
![wildcard-test](https://cloud.githubusercontent.com/assets/2432851/7213086/e75c6544-e541-11e4-911d-b05a34f318cb.PNG)

The change just points to the local node_modules path instead.