### PR TITLE
Properly support wildcard when not in a section of its own

### DIFF
--- a/test/strings.js
+++ b/test/strings.js
@@ -12,6 +12,14 @@ test('general wild card matching tests', function(t) {
     t.notOk(wildcard('a', 'a.b.c'), 'a should not match a.b.c');
 });
 
+test('regex wildcard matching tests', function(t) {
+  t.plan(4);
+  t.ok(wildcard('*foo', 'foo'), '*foo should match foo');
+  t.ok(wildcard('*foo.b', 'foo.b'), '*foo.b should match foo.b');
+  t.ok(wildcard('a.*foo.c', 'a.barfoo.c'), 'a.barfoo.c should match a.*foo.c');
+  t.ok(wildcard('a.foo*.c', 'a.foobar.c'), 'a.foobar.c should match a.foo*.c');
+});
+
 test('general wild card with separator matching tests', function(t) {
 
     t.plan(5);

--- a/test/strings.js
+++ b/test/strings.js
@@ -3,13 +3,14 @@ var test = require('tape'),
 
 test('general wild card matching tests', function(t) {
 
-    t.plan(6);
+    t.plan(7);
     t.ok(wildcard('foo.*', 'foo.bar'), 'foo.* should match foo.bar');
     t.ok(wildcard('foo.*', 'foo'), 'foo.* should match foo');
+    t.ok(wildcard('*.foo.com', 'test.foo.com'), 'test.foo.com should match *.foo.com');
     t.notOk(wildcard('foo.*', 'bar'), 'foo.* should not match bar');
     t.ok(wildcard('a.*.c', 'a.b.c'), 'a.*.c should match a.b.c');
     t.notOk(wildcard('a.*.c', 'a.b'), 'a.*.c should not match a.b');
-    t.notOk(wildcard('a', 'a.b.c'), 'a should not match a.b.c');
+    t.notOk(wildcard('a', 'a.b.c'), 'a should not match a.b.c');    
 });
 
 test('regex wildcard matching tests', function(t) {


### PR DESCRIPTION
This PR addresses the issue raised and discussed in #8 whereby a string such as `*foo` wouldn't match string `foo`.  This wasn't the goal of the library as it was only built to mimic the behaviour of the wildcard usage within [`eve`](https://github.com/adobe-webplatform/eve).  However, it is completely legitimate given the name of the package and the contexts that people would expect it to work in.

__NOTE:__ ES5 code style maintained for compatibility with older browsers, and well why rewrite for the sake of it.

 @revelt @bradennapier A quick review would be appreciated.  I think using `matcher` is the correct path forward for most people and I that as an alternative on the README, but think getting this package right is probably worthwhile also.